### PR TITLE
Handle non-existent file and tail from end

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,17 +119,16 @@ Tail = (function(_super) {
     this.inode = 0;
     this.bookmarks = {};
 
-    if (!fs.existsSync(this.filename)) 
-      throw "Filename is missing: " + this.filename;
-
-    this.fd = fs.openSync(this.filename, 'r');
-    var stat = fs.statSync(this.filename);
-    this.inode = stat.ino; 
-    this.bookmarks[this.fd] = 0;
-
-    if (this.options.start && this.fd) {
-      this.bookmarks[this.fd] = this.options.start;
-    };
+    if (fs.existsSync(this.filename)) { 
+      this.fd = fs.openSync(this.filename, 'r');
+      var stat = fs.statSync(this.filename);
+      this.inode = stat.ino;
+      if (this.options.hasOwnProperty('start')) {
+        this.bookmarks[this.fd] = this.options.start
+      } else {
+        this.bookmarks[this.fd] = stat.size;
+      }
+    }
 
     setTimeout(function() {
       self.watch();


### PR DESCRIPTION
Fixes #2 

This copes with the file not existing when it begins to watch.

It also defaults to tailing from the end of an existing file rather than spooling the entire file first. This is more consistent with the unix command, but I realise this is a change to the default behaviour. If you'd rather, I'm happy to restore the old default behaviour and add some other flag for this.
