### PR TITLE
Added blockSize option for maximum reading block size

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ var tail = new Tail(filename, separator, options);
 
 `options.start` - optional start byte to start reading from 
 
+`options.blockSize` - maximum reading block size (default is 1 MB)
+
 ## Credits
 
 Code is heavily modified from the node-tail module (https://github.com/forward/node-tail)

--- a/index.js
+++ b/index.js
@@ -50,6 +50,11 @@ Tail = (function(_super) {
 
         var size = end - start;
         if (size == 0) return next(); // no data.
+        if (size > self.blockSize) {
+          debug('block is too large, recreasing to ', self.blockSize);
+          size = self.blockSize;
+          self.queue.push(block); // for future data processing
+        }
 
         var buffer = new Buffer(size);
 
@@ -113,7 +118,8 @@ Tail = (function(_super) {
       return self.readBlock();
     });
 
-    this.interval = options.interval || 5000; 
+    this.interval = options.interval || 5000;
+    this.blockSize = options.blockSize || 1024 * 1024; // 1 MB by default
    
     this.fd = null;
     this.inode = 0;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,12 @@
     "tail"
   ],
   "author": "Jen Andre <jandre@gmail.com>",
+  "contributors": [
+  { 
+    "name": "Artur Kraev", 
+    "email": "ravenox@gmail.com"
+  }
+  ],
   "license": "MIT",
   "dependencies": {
     "debug": "~0.7.2"


### PR DESCRIPTION
Without this option there's "Out of memory" error on large files (tested on 200+ mb file)