### PR TITLE
Add the filename in the line event, useful when tailing multiple files

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ Tail = (function(_super) {
           _results = [];
           for (_i = 0, _len = parts.length; _i < _len; _i++) {
             chunk = parts[_i];
-            _results.push(self.emit("line", chunk));
+            _results.push(self.emit("line", chunk, self.filename));
           }
           next();
         });


### PR DESCRIPTION
I am using this for tailing multiple files at the same time, and I was missing the ability to also log the file it came from, with this addition the line event gives the filename the line came from back in the second parameter.