### PR TITLE
Suppress NodeJS's 7.2.1 DeprecationWarning

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ Tail = (function(_super) {
     var next = function() {
 
       if (block.type == 'close') {
-        fs.close(block.fd);
+        fs.close(block.fd, function(){});
         delete self.bookmarks[block.fd];
       };
 
@@ -161,7 +161,7 @@ Tail = (function(_super) {
     };
     
     if (self.fd) {
-      fs.close(self.fd); 
+      fs.close(self.fd, function(){}); 
       self.fd = null;
     };
 
@@ -169,7 +169,7 @@ Tail = (function(_super) {
     for (var i in self.queue) {
       var item = self.queue[i];
       if (item.type == 'close') {
-        fs.close(item.fd); 
+        fs.close(item.fd, function(){}); 
       };
     };
 


### PR DESCRIPTION
Suppress `DeprecationWarning: Calling an asynchronous function without callback is deprecated.` when calling `fs.close` without a callback.

I just added a nop function.