### PR TITLE
Fix for TypeError [ERR_INVALID_CALLBACK]: Callback must be a function…

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,11 @@ Tail = (function(_super) {
     };
     
     if (self.fd) {
-      fs.close(self.fd); 
+      /**
+       * Fix for TypeError [ERR_INVALID_CALLBACK]: Callback must be a function. Received undefined,
+       * when unwatch() is called on tail object
+       */
+      fs.close(self.fd, function() {}); 
       self.fd = null;
     };
 
@@ -169,7 +173,11 @@ Tail = (function(_super) {
     for (var i in self.queue) {
       var item = self.queue[i];
       if (item.type == 'close') {
-        fs.close(item.fd); 
+      /**
+       * Fix for TypeError [ERR_INVALID_CALLBACK]: Callback must be a function. Received undefined,
+       * when unwatch() is called on tail object
+       */
+       fs.close(item.fd, function() {}); 
       };
     };
 


### PR DESCRIPTION
**Fix for a bug filed in following github issue:**
Getting 'TypeError [ERR_INVALID_CALLBACK]: Callback must be a function. Received undefined' on tail.unwatch() #19


As per definition in https://nodejs.org/api/fs.html#fs_fs_close_fd_callback, **fs.close** expects a callback to be passed when calling it. But in the **Tail.prototype.unwatch** function, the callback is not passed and hence the function breaks when it gets called on the tail object.
